### PR TITLE
Fix: removed bad bit.ly link in NavBar

### DIFF
--- a/animal-ui/src/components/NavBar.tsx
+++ b/animal-ui/src/components/NavBar.tsx
@@ -43,7 +43,7 @@ export default function NavBar() {
                   cursor={"pointer"}
                   minW={0}
                 >
-                  <Avatar size={"sm"} src={"https://bit.ly/broken-link"} />
+                  <Avatar size={"sm"} />
                 </MenuButton>
                 <MenuList alignItems={"center"}>
                   <MenuItem>


### PR DESCRIPTION
bit.ly/broken-link is an example chakra used in their docs but should not be used in the app